### PR TITLE
refactor: do not store caches, get it dynamically

### DIFF
--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -44,6 +44,7 @@ const resource4RestartObjectMock = vi.fn();
 const resource5ReadObjectMock = vi.fn();
 
 const createdResource1InformerMock = {
+  getCache: vi.fn(),
   onCacheUpdated: vi.fn(),
   onOffline: vi.fn(),
   onObjectDeleted: vi.fn(),
@@ -52,6 +53,7 @@ const createdResource1InformerMock = {
 } as unknown as ResourceInformer<KubernetesObject>;
 
 const createdEventInformerMock = {
+  getCache: vi.fn(),
   onCacheUpdated: vi.fn(),
   onOffline: vi.fn(),
   onObjectDeleted: vi.fn(),
@@ -732,12 +734,12 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
 
     test('getResourcesCount', async () => {
       const listMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: vi.fn(),
       } as ObjectCache<KubernetesObject>);
       const listEventMock = vi.fn().mockReturnValue([{}]);
-      vi.mocked(createdEventInformerMock.start).mockReturnValue({
+      vi.mocked(createdEventInformerMock.getCache).mockReturnValue({
         list: listEventMock,
         get: vi.fn(),
       } as ObjectCache<CoreV1Event>);
@@ -765,7 +767,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
 
     test('getActiveResourcesCount', async () => {
       const listMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: vi.fn(),
       } as ObjectCache<KubernetesObject>);
@@ -795,7 +797,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
 
     test('getResources with explicit context name', async () => {
       const listMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: vi.fn(),
       } as ObjectCache<KubernetesObject>);
@@ -810,7 +812,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
 
     test('getResources without context names', async () => {
       const listMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: vi.fn(),
       } as ObjectCache<KubernetesObject>);
@@ -824,7 +826,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
 
     test('one offline informer clears all caches', async () => {
       const listMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: vi.fn(),
       } as ObjectCache<KubernetesObject>);
@@ -870,7 +872,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     test('getResourceDetails with existing resource', async () => {
       const listMock = vi.fn();
       const getMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: getMock,
       } as ObjectCache<KubernetesObject>);
@@ -885,7 +887,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     test('getResourceDetails with non-existing resource', async () => {
       const listMock = vi.fn();
       const getMock = vi.fn();
-      vi.mocked(createdResource1InformerMock.start).mockReturnValue({
+      vi.mocked(createdResource1InformerMock.getCache).mockReturnValue({
         list: listMock,
         get: getMock,
       } as ObjectCache<KubernetesObject>);
@@ -902,7 +904,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
         list: vi.fn(),
         get: vi.fn(),
       } as ObjectCache<CoreV1Event>;
-      vi.mocked(createdEventInformerMock.start).mockReturnValue(cacheMock);
+      vi.mocked(createdEventInformerMock.getCache).mockReturnValue(cacheMock);
       const event1: CoreV1Event = { metadata: {}, involvedObject: { uid: 'uid1' } };
       vi.mocked(cacheMock.list).mockReturnValue([event1]);
       vi.mocked(cacheMock.get).mockReturnValue(event1);

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -26,7 +26,6 @@ import {
   V1Ingress,
   V1Status,
   type KubernetesObject,
-  type ObjectCache,
 } from '@kubernetes/client-node';
 
 import type {
@@ -96,7 +95,6 @@ export class ContextsManager {
   #healthCheckers: Map<string, ContextHealthChecker>;
   #permissionsCheckers: ContextPermissionsChecker[];
   #informers: ContextResourceRegistry<ResourceInformer<KubernetesObject>>;
-  #objectCaches: ContextResourceRegistry<ObjectCache<KubernetesObject>>;
   #currentContext?: KubeConfigSingleContext;
   #currentKubeConfig: KubeConfig;
 
@@ -141,7 +139,6 @@ export class ContextsManager {
     this.#healthCheckers = new Map<string, ContextHealthChecker>();
     this.#permissionsCheckers = [];
     this.#informers = new ContextResourceRegistry<ResourceInformer<KubernetesObject>>();
-    this.#objectCaches = new ContextResourceRegistry<ObjectCache<KubernetesObject>>();
     this.#dispatcher = new ContextsDispatcher();
     this.#dispatcher.onUpdate(this.onUpdate.bind(this));
     this.#dispatcher.onDelete(this.onDelete.bind(this));
@@ -230,17 +227,17 @@ export class ContextsManager {
   }
 
   getResourcesCount(): ResourceCount[] {
-    return this.#objectCaches.getAll().map(informer => ({
+    return this.#informers.getAll().map(informer => ({
       contextName: informer.contextName,
       resourceName: informer.resourceName,
-      count: informer.value.list().length,
+      count: informer.value.getCache().list().length,
     }));
   }
 
   // getActiveResourcesCount returns the count of filtered resources for each context/resource
   // when isActive is declared for a resource, and filtered with isActive
   getActiveResourcesCount(): ResourceCount[] {
-    return this.#objectCaches
+    return this.#informers
       .getAll()
       .map(informer => {
         const isActive = this.#resourceFactoryHandler.getResourceFactoryByResourceName(informer.resourceName)?.isActive;
@@ -248,7 +245,7 @@ export class ContextsManager {
           ? {
               contextName: informer.contextName,
               resourceName: informer.resourceName,
-              count: informer.value.list().filter(isActive).length,
+              count: informer.value.getCache().list().filter(isActive).length,
             }
           : undefined;
       })
@@ -267,7 +264,7 @@ export class ContextsManager {
       requestContextName = currentContextName;
     }
 
-    const cache = this.#objectCaches.get(requestContextName, resourceName);
+    const cache = this.#informers.get(requestContextName, resourceName)?.getCache();
     return cache?.list() ?? [];
   }
 
@@ -277,8 +274,8 @@ export class ContextsManager {
     name: string,
     namespace?: string,
   ): KubernetesObject | undefined {
-    const value = this.#objectCaches.get(contextName, resourceName);
-    let details = value?.get(name, namespace);
+    const cache = this.#informers.get(contextName, resourceName)?.getCache();
+    let details = cache?.get(name, namespace);
     if (details) {
       const kind = this.#resourceFactoryHandler.getResourceFactoryByResourceName(resourceName)?.kind;
       details = { ...details, kind };
@@ -288,8 +285,9 @@ export class ContextsManager {
 
   getResourceEvents(contextName: string, uid: string): CoreV1Event[] {
     return (
-      this.#objectCaches
+      this.#informers
         .get(contextName, 'events')
+        ?.getCache()
         ?.list()
         .filter(o => this.isCoreV1Event(o))
         .filter(event => event.involvedObject.uid === uid) ?? []
@@ -355,7 +353,7 @@ export class ContextsManager {
         contextName: informer.contextName,
         resourceName: informer.resourceName,
         isOffline: informer.value.isOffline(),
-        objectsCount: this.#objectCaches.get(informer.contextName, informer.resourceName)?.list().length,
+        objectsCount: this.#informers.get(informer.contextName, informer.resourceName)?.getCache()?.list().length,
       })),
     };
   }
@@ -429,7 +427,7 @@ export class ContextsManager {
             });
             informer.onOffline((e: OfflineEvent) => {
               this.#onOfflineChange.fire();
-              this.#objectCaches.removeForContext(e.kubeconfig.getKubeConfig().currentContext);
+              this.#informers.removeForContext(e.kubeconfig.getKubeConfig().currentContext);
             });
             informer.onObjectDeleted((e: ObjectDeletedEvent) => {
               this.#onObjectDeleted.fire({
@@ -439,8 +437,7 @@ export class ContextsManager {
                 namespace: e.namespace,
               });
             });
-            const cache = informer.start();
-            this.#objectCaches.set(contextName, resource, cache);
+            informer.start();
           }
         });
         await newPermissionChecker.start();
@@ -468,7 +465,6 @@ export class ContextsManager {
       informer.dispose();
     }
     this.#informers.removeForContext(contextName);
-    this.#objectCaches.removeForContext(contextName);
   }
 
   // returns true if at least one informer for the context is 'offline'

--- a/packages/extension/src/types/resource-informer.spec.ts
+++ b/packages/extension/src/types/resource-informer.spec.ts
@@ -81,7 +81,8 @@ test('ResourceInformer should eventually return the list of resources', async ()
     kind: 'MyResource',
     plural: 'myresources',
   });
-  const result = informer.start();
+  informer.start();
+  const result = informer.getCache();
   await vi.waitFor(() => {
     const list = result.list();
     expect(list).toEqual(items.map(i => ({ apiVersion: 'v8', kind: 'MyResource', ...i })));


### PR DESCRIPTION
This is needed to be able to have different type of cache, either the internal one, or some cache with step by step