### PR TITLE
feat: start/stop debugger

### DIFF
--- a/packages/channels/src/channels.ts
+++ b/packages/channels/src/channels.ts
@@ -36,6 +36,7 @@ import type { ResourceEventsInfo } from './model/resource-events-info';
 import type { ResourcesCountInfo } from './model/resources-count-info';
 import type { UpdateResourceInfo } from './model/update-resource-info';
 import { createRpcChannel } from '@kubernetes-dashboard/rpc';
+import type { DebuggerInfo } from '/@/model/debugger-info';
 
 // RPC channels (used by the webview to send requests to the extension)
 export const API_CONTEXTS = createRpcChannel<ContextsApi>('ContextsApi');
@@ -55,6 +56,7 @@ export const RESOURCE_DETAILS = createRpcChannel<ResourceDetailsInfo>('ResourceD
 export const RESOURCE_EVENTS = createRpcChannel<ResourceEventsInfo>('ResourceEvents');
 export const PORT_FORWARDS = createRpcChannel<PortForwardsInfo>('PortForwards');
 export const ENDPOINTS = createRpcChannel<EndpointsInfo>('Endpoints');
+export const DEBUGGER = createRpcChannel<DebuggerInfo>('Debugger');
 
 // Channels fot streams
 export const API_POD_LOGS = createRpcChannel<PodLogsApi>('PodLogsApi');

--- a/packages/channels/src/model/debugger-info.ts
+++ b/packages/channels/src/model/debugger-info.ts
@@ -16,15 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const ContextsApi = Symbol.for('ContextsApi');
-
-export interface ContextsApi {
-  setCurrentContext(contextName: string): Promise<void>;
-  refreshContextState(contextName: string): Promise<void>;
-  deleteObject(kind: string, name: string, namespace?: string): Promise<void>;
-  deleteObjects(objects: { kind: string; name: string; namespace?: string }[]): Promise<void>;
-  setCurrentNamespace(namespace: string): Promise<void>;
-  restartObject(kind: string, name: string, namespace: string): Promise<void>;
-  applyResources(yamlDocuments: string): Promise<void>;
-  setStepByStepMode(stepByStep: boolean): Promise<void>;
+export interface DebuggerInfo {
+  active: boolean;
 }

--- a/packages/channels/src/model/index.ts
+++ b/packages/channels/src/model/index.ts
@@ -24,6 +24,7 @@ export * from './context-resources-items';
 export * from './contexts-healths-info';
 export * from './contexts-permissions-info';
 export * from './current-context-info';
+export * from './debugger-info';
 export * from './endpoint';
 export * from './endpoints-info';
 export * from './endpoints-options';

--- a/packages/extension/src/dispatcher/_dispatcher-module.ts
+++ b/packages/extension/src/dispatcher/_dispatcher-module.ts
@@ -29,6 +29,7 @@ import { ResourceEventsDispatcher } from './resource-events-dispatcher';
 import { PortForwardsDispatcher } from './port-forwards-dispatcher';
 import { EndpointsDispatcher } from './endpoints-dispatcher';
 import { AvailableContextsDispatcher } from './available-contexts-dispatcher';
+import { DebuggerDispatcher } from '/@/dispatcher/debugger-dispatcher';
 
 const dispatchersModule = new ContainerModule(options => {
   options.bind<ActiveResourcesCountDispatcher>(ActiveResourcesCountDispatcher).toSelf().inSingletonScope();
@@ -63,6 +64,9 @@ const dispatchersModule = new ContainerModule(options => {
 
   options.bind<EndpointsDispatcher>(EndpointsDispatcher).toSelf().inSingletonScope();
   options.bind(DispatcherObject).toService(EndpointsDispatcher);
+
+  options.bind<DebuggerDispatcher>(DebuggerDispatcher).toSelf().inSingletonScope();
+  options.bind(DispatcherObject).toService(DebuggerDispatcher);
 });
 
 export { dispatchersModule };

--- a/packages/extension/src/dispatcher/debugger-dispatcher.ts
+++ b/packages/extension/src/dispatcher/debugger-dispatcher.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+import type { DispatcherObject } from './util/dispatcher-object';
+import { AbsDispatcherObjectImpl } from './util/dispatcher-object';
+import { ContextsManager } from '/@/manager/contexts-manager';
+import { RpcExtension } from '@kubernetes-dashboard/rpc';
+import { DEBUGGER, type DebuggerInfo } from '@kubernetes-dashboard/channels';
+
+@injectable()
+export class DebuggerDispatcher extends AbsDispatcherObjectImpl<void, DebuggerInfo> implements DispatcherObject<void> {
+  constructor(
+    @inject(RpcExtension) rpcExtension: RpcExtension,
+    @inject(ContextsManager) private manager: ContextsManager,
+  ) {
+    super(rpcExtension, DEBUGGER);
+  }
+
+  getData(): DebuggerInfo {
+    return {
+      active: this.manager.isStepByStepMode(),
+    };
+  }
+}

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -44,6 +44,7 @@ const resource4RestartObjectMock = vi.fn();
 const resource5ReadObjectMock = vi.fn();
 
 const createdResource1InformerMock = {
+  setStepByStepMode: vi.fn(),
   getCache: vi.fn(),
   onCacheUpdated: vi.fn(),
   onOffline: vi.fn(),
@@ -53,6 +54,7 @@ const createdResource1InformerMock = {
 } as unknown as ResourceInformer<KubernetesObject>;
 
 const createdEventInformerMock = {
+  setStepByStepMode: vi.fn(),
   getCache: vi.fn(),
   onCacheUpdated: vi.fn(),
   onOffline: vi.fn(),
@@ -934,6 +936,18 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
       expect(createdResource1InformerMock.start).toHaveBeenCalledTimes(2);
       expect(onObjectDeletedCB).toHaveBeenCalledTimes(2);
     });
+
+    describe('step by step mode is set', () => {
+      beforeEach(async () => {
+        await manager.update(kc);
+        await manager.setStepByStepMode(true);
+      });
+
+      test('calls setStepByStepMode on informers', async () => {
+        expect(createdResource1InformerMock.setStepByStepMode).toHaveBeenCalledWith(true);
+        expect(createdEventInformerMock.setStepByStepMode).toHaveBeenCalledWith(true);
+      });
+    });
   });
 });
 
@@ -1794,5 +1808,43 @@ describe.each([
     const manager = new TestContextsManager();
     const result = manager.getPluralized(count, kind);
     expect(result).toEqual(message);
+  });
+});
+
+describe('step by step mode', () => {
+  test('is not set by default', () => {
+    const manager = new TestContextsManager();
+    expect(manager.isStepByStepMode()).toBe(false);
+  });
+  test('can be set', async () => {
+    const manager = new TestContextsManager();
+    await manager.setStepByStepMode(true);
+    expect(manager.isStepByStepMode()).toBe(true);
+  });
+
+  test('can be unset', async () => {
+    const manager = new TestContextsManager();
+    await manager.setStepByStepMode(true);
+    expect(manager.isStepByStepMode()).toBe(true);
+    await manager.setStepByStepMode(false);
+    expect(manager.isStepByStepMode()).toBe(false);
+  });
+
+  test('dispatch step by step mode change', async () => {
+    const manager = new TestContextsManager();
+    const onStepByStepChangeCB: (e: void) => unknown = vi.fn();
+    manager.onStepByStepChange(onStepByStepChangeCB);
+    await manager.setStepByStepMode(true);
+    expect(onStepByStepChangeCB).toHaveBeenCalledWith(undefined);
+    await manager.setStepByStepMode(false);
+    expect(onStepByStepChangeCB).toHaveBeenCalledWith(undefined);
+  });
+
+  test('step by step mode is unset when context monitoring is stopped', async () => {
+    const manager = new TestContextsManager();
+    await manager.setStepByStepMode(true);
+    expect(manager.isStepByStepMode()).toBe(true);
+    manager.stopMonitoring('ctx1');
+    expect(manager.isStepByStepMode()).toBe(false);
   });
 });

--- a/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.spec.ts
@@ -39,6 +39,7 @@ import {
   CONTEXTS_HEALTHS,
   CONTEXTS_PERMISSIONS,
   CURRENT_CONTEXT,
+  DEBUGGER,
   ENDPOINTS,
   RESOURCE_DETAILS,
   RESOURCE_EVENTS,
@@ -60,6 +61,7 @@ const contextsManagerMock: ContextsManager = {
   isContextOffline: vi.fn(),
   onCurrentContextChange: vi.fn(),
   onEndpointsChange: vi.fn(),
+  onStepByStepChange: vi.fn(),
 } as unknown as ContextsManager;
 const rpcExtension: RpcExtension = {
   fire: vi.fn(),
@@ -215,4 +217,17 @@ test('ContextsStatesDispatcher should dispatch ENDPOINTS when onEndpointsChange 
     expect(dispatcherSpy).toHaveBeenCalledTimes(1);
   });
   expect(dispatcherSpy).toHaveBeenCalledWith(ENDPOINTS);
+});
+
+test('ContextsStatesDispatcher should dispatch DEBUGGER when onStepByStepChange event is fired', async () => {
+  const dispatcherSpy = vi.spyOn(dispatcher, 'dispatch').mockResolvedValue();
+  dispatcher.init();
+  expect(dispatcherSpy).not.toHaveBeenCalled();
+
+  vi.mocked(contextsManagerMock.onStepByStepChange).mockImplementation(f => f() as IDisposable);
+  dispatcher.init();
+  await vi.waitFor(() => {
+    expect(dispatcherSpy).toHaveBeenCalledTimes(1);
+  });
+  expect(dispatcherSpy).toHaveBeenCalledWith(DEBUGGER);
 });

--- a/packages/extension/src/manager/contexts-states-dispatcher.ts
+++ b/packages/extension/src/manager/contexts-states-dispatcher.ts
@@ -30,6 +30,7 @@ import {
   RESOURCES_COUNT,
   UPDATE_RESOURCE,
   SubscribeApi,
+  DEBUGGER,
 } from '@kubernetes-dashboard/channels';
 
 import type { ContextHealthState } from './context-health-checker.js';
@@ -99,6 +100,9 @@ export class ContextsStatesDispatcher extends ChannelSubscriber implements Subsc
       await this.dispatch(ENDPOINTS);
     });
     this.onSubscribe(channelName => this.dispatchByChannelName(channelName));
+    this.manager.onStepByStepChange(async () => {
+      await this.dispatch(DEBUGGER);
+    });
   }
 
   // TODO replace this with an event

--- a/packages/webview/src/AppWithContext.svelte
+++ b/packages/webview/src/AppWithContext.svelte
@@ -25,9 +25,11 @@ import JobDetails from './component/jobs/JobDetails.svelte';
 import CronJobDetails from './component/cronjobs/CronJobDetails.svelte';
 import PodDetails from './component/pods/PodDetails.svelte';
 import PortForwardingList from './component/port-forward/PortForwardingList.svelte';
+import Debugger from '/@/component/debugger/Debugger.svelte';
+import type { TinroRouteMeta } from 'tinro';
+
 // import globally the monaco environment
 import './monaco-environment';
-import type { TinroRouteMeta } from 'tinro';
 
 interface Props {
   meta: TinroRouteMeta;
@@ -133,5 +135,9 @@ const { meta }: Props = $props();
 
   <Route path="/portForward">
     <PortForwardingList />
+  </Route>
+
+  <Route path="/debugger">
+    <Debugger />
   </Route>
 </div>

--- a/packages/webview/src/Navigation.svelte
+++ b/packages/webview/src/Navigation.svelte
@@ -77,5 +77,7 @@ const navigator = dependencyAccessor.get<Navigator>(Navigator);
       href={navigator.kubernetesResourcesURL('CronJob')} />
 
     <SettingsNavItem title="Port Forwarding" selected={meta.url === '/portForward'} href="/portForward" />
+
+    <SettingsNavItem title="Debugger" selected={meta.url === '/debugger'} href="/debugger" />
   </div>
 </nav>

--- a/packages/webview/src/component/debugger/Debugger.svelte
+++ b/packages/webview/src/component/debugger/Debugger.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+import { getContext, onDestroy, onMount } from 'svelte';
+import { Remote } from '/@/remote/remote';
+import { API_CONTEXTS, type ContextsApi } from '@kubernetes-dashboard/channels';
+import { NavPage } from '@podman-desktop/ui-svelte';
+import { States } from '/@/state/states';
+import type { Unsubscriber } from 'svelte/store';
+import { faPlay, faStop } from '@fortawesome/free-solid-svg-icons';
+import IconButton from '/@/component/button/IconButton.svelte';
+
+const remote = getContext<Remote>(Remote);
+const contextsApi = remote.getProxy<ContextsApi>(API_CONTEXTS);
+const states = getContext<States>(States);
+const debuggerInfo = states.stateDebuggerInfoUI;
+
+let unsubscriber: Unsubscriber | undefined;
+
+onMount(() => {
+  unsubscriber = debuggerInfo.subscribe();
+});
+
+onDestroy(() => {
+  unsubscriber?.();
+  unsubscriber = undefined;
+});
+</script>
+
+<NavPage searchEnabled={false} title="Debugger">
+  {#snippet additionalActions()}
+    <div class="flex grow justify-end">
+      <IconButton
+        enabled={!debuggerInfo.data?.active}
+        title="Start debugger"
+        onClick={async (): Promise<void> => {
+          await contextsApi.setStepByStepMode(true);
+        }}
+        icon={faPlay} />
+      <IconButton
+        enabled={debuggerInfo.data?.active}
+        title="Stop debugger"
+        onClick={async (): Promise<void> => {
+          await contextsApi.setStepByStepMode(false);
+        }}
+        icon={faStop} />
+    </div>
+  {/snippet}
+</NavPage>

--- a/packages/webview/src/state/debugger.svelte.ts
+++ b/packages/webview/src/state/debugger.svelte.ts
@@ -16,15 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const ContextsApi = Symbol.for('ContextsApi');
+import { inject, injectable } from 'inversify';
 
-export interface ContextsApi {
-  setCurrentContext(contextName: string): Promise<void>;
-  refreshContextState(contextName: string): Promise<void>;
-  deleteObject(kind: string, name: string, namespace?: string): Promise<void>;
-  deleteObjects(objects: { kind: string; name: string; namespace?: string }[]): Promise<void>;
-  setCurrentNamespace(namespace: string): Promise<void>;
-  restartObject(kind: string, name: string, namespace: string): Promise<void>;
-  applyResources(yamlDocuments: string): Promise<void>;
-  setStepByStepMode(stepByStep: boolean): Promise<void>;
+import { DEBUGGER, type DebuggerInfo } from '@kubernetes-dashboard/channels';
+import { RpcBrowser } from '@kubernetes-dashboard/rpc';
+
+import { AbsStateObjectImpl, type StateObject } from './util/state-object.svelte';
+
+// Define a state for the DebuggerInfo
+@injectable()
+export class StateDebuggerInfo
+  extends AbsStateObjectImpl<DebuggerInfo, void>
+  implements StateObject<DebuggerInfo, void>
+{
+  constructor(@inject(RpcBrowser) rpcBrowser: RpcBrowser) {
+    super(rpcBrowser);
+  }
+
+  async init(): Promise<void> {
+    await this.initChannel(DEBUGGER);
+  }
 }

--- a/packages/webview/src/state/state-module.ts
+++ b/packages/webview/src/state/state-module.ts
@@ -32,6 +32,7 @@ import { StateResourceEventsInfo } from './resource-events.svelte';
 import { StatePortForwardsInfo } from './port-forwards.svelte';
 import { StateEndpointsInfo } from './endpoints.svelte';
 import { StateAvailableContextsInfo } from './available-contexts.svelte';
+import { StateDebuggerInfo } from '/@/state/debugger.svelte';
 
 const statesModule = new ContainerModule(options => {
   options.bind(States).toSelf().inSingletonScope();
@@ -79,6 +80,10 @@ const statesModule = new ContainerModule(options => {
   options.bind(StateEndpointsInfo).toSelf().inSingletonScope();
   options.bind(StateObject).toService(StateEndpointsInfo);
   options.bind(IDisposable).toService(StateEndpointsInfo);
+
+  options.bind(StateDebuggerInfo).toSelf().inSingletonScope();
+  options.bind(StateObject).toService(StateDebuggerInfo);
+  options.bind(IDisposable).toService(StateDebuggerInfo);
 });
 
 export { statesModule };

--- a/packages/webview/src/state/states.ts
+++ b/packages/webview/src/state/states.ts
@@ -28,6 +28,7 @@ import { StateResourceEventsInfo } from './resource-events.svelte';
 import { StatePortForwardsInfo } from './port-forwards.svelte';
 import { StateEndpointsInfo } from './endpoints.svelte';
 import { StateAvailableContextsInfo } from './available-contexts.svelte';
+import { StateDebuggerInfo } from '/@/state/debugger.svelte';
 
 @injectable()
 export class States {
@@ -106,5 +107,12 @@ export class States {
 
   get stateEndpointsInfoUI(): StateEndpointsInfo {
     return this._stateEndpointsInfoUI;
+  }
+
+  @inject(StateDebuggerInfo)
+  private _stateDebuggerInfoUI: StateDebuggerInfo;
+
+  get stateDebuggerInfoUI(): StateDebuggerInfo {
+    return this._stateDebuggerInfoUI;
   }
 }


### PR DESCRIPTION
Adds a new Debugger page, and start/stop buttons to enable or disable debugger.

When the debugger is enabled, changes on resources are not reflected. Next PRs will make these changes visible in the Debugger page, and the user will be able to enable these changes.